### PR TITLE
Fix output.bov in mpi miniapp solution

### DIFF
--- a/miniapp/solutions/mpi/cxx/main.cpp
+++ b/miniapp/solutions/mpi/cxx/main.cpp
@@ -287,7 +287,7 @@ int main(int argc, char* argv[])
         std::ofstream fid("output.bov");
         fid << "TIME: 0.0" << std::endl;
         fid << "DATA_FILE: output.bin" << std::endl;
-        fid << "DATA_SIZE: " << options.nx << ", " << options.ny << ", 1" << std::endl;;
+        fid << "DATA_SIZE: " << options.nx << " " << options.ny << " 1" << std::endl;;
         fid << "DATA_FORMAT: DOUBLE" << std::endl;
         fid << "VARIABLE: phi" << std::endl;
         fid << "DATA_ENDIAN: LITTLE" << std::endl;


### PR DESCRIPTION
Remove "," in output.bov
The same problem is very likely also in openmp solution