### PR TITLE
Fix problem with output.bov in miniapp openmp cxx solution

### DIFF
--- a/miniapp/solutions/openmp/cxx/main.cpp
+++ b/miniapp/solutions/openmp/cxx/main.cpp
@@ -230,7 +230,7 @@ int main(int argc, char* argv[])
     std::ofstream fid("output.bov");
     fid << "TIME: 0.0" << std::endl;
     fid << "DATA_FILE: output.bin" << std::endl;
-    fid << "DATA_SIZE: " << options.nx << ", " << options.ny << ", 1" << std::endl;;
+    fid << "DATA_SIZE: " << options.nx << " " << options.ny << " 1" << std::endl;;
     fid << "DATA_FORMAT: DOUBLE" << std::endl;
     fid << "VARIABLE: phi" << std::endl;
     fid << "DATA_ENDIAN: LITTLE" << std::endl;


### PR DESCRIPTION
I think there is also some problem in miniapp/solution/openmp/fortran. The plot script crashes, but for different reason and I have no idea why.
It is too late now. We can look at it another day.